### PR TITLE
feat: get user info (#20)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/rubenv/sql-migrate v1.7.1/go.mod h1:Ob2Psprc0/3ggbM6wCzyYVFFuc6FyZrb2
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/userapp/delivery/http/server.go
+++ b/userapp/delivery/http/server.go
@@ -41,5 +41,6 @@ func (s Server) RegisterRoutes() {
 
 	userGroup := v1.Group("/users")
 	userGroup.GET("/", s.Handler.GetAllUsers)
+	userGroup.GET("/users/:id", s.Handler.GetUser)
 	userGroup.POST("/login", s.Handler.Login)
 }

--- a/userapp/delivery/http/server.go
+++ b/userapp/delivery/http/server.go
@@ -41,6 +41,6 @@ func (s Server) RegisterRoutes() {
 
 	userGroup := v1.Group("/users")
 	userGroup.GET("/", s.Handler.GetAllUsers)
-	userGroup.GET("/users/:id", s.Handler.GetUser)
+	userGroup.GET("/:id", s.Handler.GetUser)
 	userGroup.POST("/login", s.Handler.Login)
 }

--- a/userapp/repository/user.go
+++ b/userapp/repository/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/gocastsian/roham/types"
 	"log/slog"
 
 	"github.com/gocastsian/roham/userapp/service/user"
@@ -130,4 +131,68 @@ func (repo UserRepo) checkUserExist(ctx context.Context, phoneNumber string) (bo
 	}
 
 	return true, nil
+}
+
+func (repo UserRepo) GetUser(ctx context.Context, ID types.ID) (user.User, error) {
+	// Check if the user exists
+	exists, err := repo.checkUserExistByID(ctx, ID)
+	if err != nil {
+		return user.User{}, fmt.Errorf("failed to check user existence: %w", err)
+	}
+
+	if exists == false {
+		return user.User{}, fmt.Errorf("the user not found")
+	}
+
+	// Query to fetch the user's details
+	query := "SELECT id, username, first_name, last_name, email, phone_number, birth_date, created_at, updated_at, role FROM users WHERE ID=$1"
+	stmt, err := repo.PostgreSQL.PrepareContext(ctx, query)
+	if err != nil {
+		return user.User{}, fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	var usr user.User
+	err = stmt.QueryRowContext(ctx, ID).Scan(
+		&usr.ID,
+		&usr.Username,
+		&usr.FirstName,
+		&usr.LastName,
+		&usr.Email,
+		&usr.PhoneNumber,
+		&usr.BirthDate,
+		&usr.CreatedAt,
+		&usr.UpdatedAt,
+		&usr.Role,
+	)
+	if err != nil {
+		return user.User{}, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	return usr, nil
+}
+
+func (repo UserRepo) checkUserExistByID(ctx context.Context, ID types.ID) (bool, error) {
+
+	query := `
+		SELECT EXISTS (
+			SELECT 1
+			FROM users
+			WHERE ID = $1
+		)
+	`
+
+	stmt, err := repo.PostgreSQL.PrepareContext(ctx, query)
+	if err != nil {
+		return false, fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	var exists bool
+	err = stmt.QueryRowContext(ctx, ID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute prepared statement: %w", err)
+	}
+
+	return exists, nil
 }

--- a/userapp/repository/user.go
+++ b/userapp/repository/user.go
@@ -140,7 +140,7 @@ func (repo UserRepo) GetUser(ctx context.Context, ID types.ID) (user.User, error
 		return user.User{}, fmt.Errorf("failed to check user existence: %w", err)
 	}
 
-	if exists == false {
+	if !exists {
 		return user.User{}, fmt.Errorf("the user not found")
 	}
 

--- a/userapp/service/user/service.go
+++ b/userapp/service/user/service.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"fmt"
+	"github.com/gocastsian/roham/types"
 	"log/slog"
 
 	errmsg "github.com/gocastsian/roham/pkg/err_msg"
@@ -13,6 +14,7 @@ import (
 type Repository interface {
 	GetAllUsers(ctx context.Context) ([]User, error)
 	GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (User, error)
+	GetUser(ctx context.Context, ID types.ID) (User, error)
 }
 
 type Service struct {
@@ -111,4 +113,32 @@ func (srv Service) Login(ctx context.Context, loginReq LoginRequest) (LoginRespo
 			RefreshToken: refreshTok,
 		},
 	}, nil
+}
+
+func (srv Service) GetUser(ctx context.Context, userID types.ID) (GetAllUsersItem, error) {
+
+	user, err := srv.repository.GetUser(ctx, userID)
+	if err != nil {
+		srv.logger.Error("user_GetUser", slog.Any("err", err))
+		return GetAllUsersItem{}, errmsg.ErrorResponse{
+			Message: err.Error(),
+			Errors: map[string]interface{}{
+				"user_GetUser": err.Error(),
+			},
+		}
+	}
+	responseUser := GetAllUsersItem{
+		ID:          user.ID,
+		Username:    user.Username,
+		FirstName:   user.FirstName,
+		LastName:    user.LastName,
+		Avatar:      user.Avatar,
+		PhoneNumber: user.PhoneNumber,
+		Email:       user.Email,
+		BirthDate:   user.BirthDate,
+		CreatedAt:   user.CreatedAt,
+		UpdatedAt:   user.UpdatedAt,
+		Role:        user.Role,
+	}
+	return responseUser, nil
 }

--- a/userapp/service/user/service.go
+++ b/userapp/service/user/service.go
@@ -119,7 +119,6 @@ func (srv Service) GetUser(ctx context.Context, userID types.ID) (GetAllUsersIte
 
 	user, err := srv.repository.GetUser(ctx, userID)
 	if err != nil {
-		srv.logger.Error("user_GetUser", slog.Any("err", err))
 		return GetAllUsersItem{}, errmsg.ErrorResponse{
 			Message: err.Error(),
 			Errors: map[string]interface{}{

--- a/userapp/service/user/service_test.go
+++ b/userapp/service/user/service_test.go
@@ -1,0 +1,81 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gocastsian/roham/types"
+	"github.com/gocastsian/roham/userapp/service/guard"
+	"github.com/gocastsian/roham/userapp/service/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockRepository struct {
+	mock.Mock
+}
+
+func (m *MockRepository) GetAllUsers(ctx context.Context) ([]user.User, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]user.User), args.Error(1)
+}
+
+func (m *MockRepository) GetUserByPhoneNumber(ctx context.Context, phoneNumber string) (user.User, error) {
+	args := m.Called(ctx, phoneNumber)
+	return args.Get(0).(user.User), args.Error(1)
+}
+
+func (m *MockRepository) CheckUserExist(ctx context.Context, phoneNumber string) (bool, error) {
+	args := m.Called(ctx, phoneNumber)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRepository) GetUser(ctx context.Context, ID types.ID) (user.User, error) {
+	args := m.Called(ctx, ID)
+	return args.Get(0).(user.User), args.Error(1)
+}
+
+func (m *MockRepository) CheckUserExistByID(ctx context.Context, ID types.ID) (bool, error) {
+	args := m.Called(ctx, ID)
+	return args.Bool(0), args.Error(1)
+}
+
+func TestGetUser_Success(t *testing.T) {
+	mockRepo := new(MockRepository)
+	userValidator := user.NewValidator(mockRepo)
+	guardSvc := &guard.Service{}
+
+	service := user.NewService(mockRepo, userValidator, nil, guardSvc)
+
+	testUser := user.User{
+		ID:        0,
+		Username:  "test",
+		FirstName: "firstname",
+		LastName:  "lastname",
+		Email:     "email@gmail.com",
+		Avatar:    "",
+		Role:      0,
+	}
+	mockRepo.On("CheckUserExistByID", mock.Anything, types.ID(0)).Return(true, nil)
+	mockRepo.On("GetUser", mock.Anything, types.ID(0)).Return(testUser, nil)
+
+	res, err := service.GetUser(context.Background(), types.ID(0))
+	assert.NoError(t, err)
+	assert.Equal(t, types.ID(0), res.ID)
+}
+
+func TestGetUser_NotExist(t *testing.T) {
+	mockRepo := new(MockRepository)
+	userValidator := user.NewValidator(mockRepo)
+	guardSvc := &guard.Service{}
+
+	service := user.NewService(mockRepo, userValidator, nil, guardSvc)
+
+	mockRepo.On("CheckUserExistByID", mock.Anything, types.ID(0)).Return(false, nil)
+	mockRepo.On("GetUser", mock.Anything, types.ID(0)).Return(user.User{}, errors.New("the user not found"))
+
+	_, err := service.GetUser(context.Background(), types.ID(0))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "the user not found")
+}


### PR DESCRIPTION
Hi Hossein

This PR adds a new endpoint to the user APIs that allows clients to retrieve user details using the user's id as a query parameter.
Note that no access control is performed for this API. Depending on the security requirements due to sensitive data such as PhoneNumbers and Emails in the response, we might want to add authorization checks.

Tanks